### PR TITLE
feat: make build creates a package image with package.yaml for contro…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ UPTEST_VERSION = v0.2.1
 # Setup Images
 
 REGISTRY_ORGS ?= xpkg.upbound.io/upbound
-IMAGES = $(PROJECT_NAME)
+IMAGES = $(PROJECT_NAME) $(PROJECT_NAME)-package
 -include build/makelib/imagelight.mk
 
 # ====================================================================================

--- a/cluster/images/provider-opsgenie-package/Dockerfile
+++ b/cluster/images/provider-opsgenie-package/Dockerfile
@@ -1,0 +1,2 @@
+FROM scratch
+COPY package.yaml .

--- a/cluster/images/provider-opsgenie-package/Makefile
+++ b/cluster/images/provider-opsgenie-package/Makefile
@@ -1,0 +1,20 @@
+# ====================================================================================
+# Setup Project
+
+include ../../../build/makelib/common.mk
+
+# ====================================================================================
+#  Options
+
+include ../../../build/makelib/imagelight.mk
+
+# ====================================================================================
+# Targets
+
+img.build:
+	@$(INFO) docker build $(IMAGE)
+	@cp Dockerfile $(IMAGE_TEMP_DIR) || $(FAIL)
+	@cp -R ../../../package $(IMAGE_TEMP_DIR) || $(FAIL)
+	@cd $(IMAGE_TEMP_DIR) && find package -type f -name '*.yaml' -exec cat {} >> 'package.yaml' \; -exec printf '\n---\n' \; || $(FAIL)
+	@docker build -t $(IMAGE) $(IMAGE_TEMP_DIR) || $(FAIL)
+	@$(OK) docker build $(IMAGE)


### PR DESCRIPTION
### Description of your changes

When running `make build` a `<project-name>-package` image will be built which is just a scratch image with the `package.yaml` file, you can then push it to your registry and reference it in your `Provider`, instead of using Upbound Market.

```
apiVersion: pkg.crossplane.io/v1
kind: Provider
metadata:
  name: opsgenie
spec:
  package: my-repo/provider-opsgenie-package-amd64:some-tag
```


I have:
- [x] Run `make reviewable test` to ensure this PR is ready for review.

