### PR TITLE
feat: support for tag and registry push

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -200,3 +200,14 @@ crossplane.help:
 help-special: crossplane.help
 
 .PHONY: crossplane.help help-special
+
+
+# ====================================================================================
+# Custom targets
+
+push:
+	@$(INFO) Pushing images to registry
+	$(foreach i, $(IMAGES), docker push $(BUILD_REGISTRY)/$(i)-$(ARCH):$(VERSION);)
+	@$(OK) Done...
+
+.PHONY: push

--- a/cluster/images/provider-opsgenie-package/Makefile
+++ b/cluster/images/provider-opsgenie-package/Makefile
@@ -11,10 +11,16 @@ include ../../../build/makelib/imagelight.mk
 # ====================================================================================
 # Targets
 
+img.publish:
+	@$(INFO) Skipping image publish for $(IMAGE)
+	@echo Publish is deferred to xpkg machinery
+	@$(OK) Image publish skipped for $(IMAGE)
+
 img.build:
 	@$(INFO) docker build $(IMAGE)
 	@cp Dockerfile $(IMAGE_TEMP_DIR) || $(FAIL)
 	@cp -R ../../../package $(IMAGE_TEMP_DIR) || $(FAIL)
 	@cd $(IMAGE_TEMP_DIR) && find package -type f -name '*.yaml' -exec cat {} >> 'package.yaml' \; -exec printf '\n---\n' \; || $(FAIL)
 	@docker build -t $(IMAGE) $(IMAGE_TEMP_DIR) || $(FAIL)
+	@docker tag $(IMAGE) "$(IMAGE):$(VERSION)" || $(FAIL)
 	@$(OK) docker build $(IMAGE)

--- a/cluster/images/provider-opsgenie/Makefile
+++ b/cluster/images/provider-opsgenie/Makefile
@@ -35,6 +35,7 @@ img.build.shared:
 		--build-arg TERRAFORM_NATIVE_PROVIDER_BINARY=$(TERRAFORM_NATIVE_PROVIDER_BINARY) \
 		-t $(IMAGE) \
 		$(IMAGE_TEMP_DIR) || $(FAIL)
+	@docker tag $(IMAGE) "$(IMAGE):$(VERSION)" || $(FAIL)
 
 img.promote:
 	@$(INFO) Skipping image promotion from $(FROM_IMAGE) to $(TO_IMAGE)


### PR DESCRIPTION
### Description of your changes

The `make build` command now also tags the images with the `VERSION` variable. 
Set the `VERSION` to your desired image semantic tag and `BUILD_REGISTRY` to your registry URL.

Added a `make push` command to push the images to the registry.

Eg.
```
export VERSION=v0.0.1
export BUILD_REGISTRY=some.io/registry
make build
make push
```