### PR TITLE
feat: added release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,98 @@
+name: Build and release
+on:
+  push:
+    branches:
+      - "!*"
+    tags:
+      - "v*"
+env:
+  # Common versions
+  GO_VERSION: "1.19"
+  GOLANGCI_VERSION: "v1.50.0"
+  DOCKER_BUILDX_VERSION: "v0.8.2"
+
+jobs:
+  build-n-push:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Set environment variables
+        run: |
+          echo VERSION=$GITHUB_REF_NAME >> $GITHUB_ENV
+          echo BUILD_REGISTRY=${{ secrets.BUILD_REGISTRY }} >> $GITHUB_ENV
+
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: all
+
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          version: ${{ env.DOCKER_BUILDX_VERSION }}
+          install: true
+
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: true
+
+      - name: "Authenticate to Google Cloud"
+        uses: "google-github-actions/auth@v1"
+        with:
+          credentials_json: "${{ secrets.GCP_CREDENTIALS }}"
+
+      - name: "Set up Cloud SDK"
+        uses: "google-github-actions/setup-gcloud@v1"
+
+      - name: "Configure Docker"
+        run: "gcloud auth configure-docker europe-west3-docker.pkg.dev --quiet"
+
+      - name: Fetch History
+        run: git fetch --prune --unshallow
+
+      - name: Setup Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Find the Go Build Cache
+        id: go
+        run: echo "::set-output name=cache::$(make go.cachedir)"
+
+      - name: Cache the Go Build Cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.go.outputs.cache }}
+          key: ${{ runner.os }}-build-publish-artifacts-${{ hashFiles('**/go.sum') }}
+          restore-keys: ${{ runner.os }}-build-publish-artifacts-
+
+      - name: Cache Go Dependencies
+        uses: actions/cache@v2
+        with:
+          path: .work/pkg
+          key: ${{ runner.os }}-pkg-${{ hashFiles('**/go.sum') }}
+          restore-keys: ${{ runner.os }}-pkg-
+
+      - name: Vendor Dependencies
+        run: make vendor vendor.check
+
+      - name: Build Artifacts
+        run: make build
+        env:
+          # We're using docker buildx, which doesn't actually load the images it
+          # builds by default. Specifying --load does so.
+          BUILD_ARGS: "--load"
+
+      - name: Push Images
+        run: make push
+
+  create-release:
+    runs-on: ubuntu-22.04
+    needs: build-n-push
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ncipollo/release-action@v1
+        with:
+          generateReleaseNotes: true

--- a/cluster/images/provider-opsgenie-package/Makefile
+++ b/cluster/images/provider-opsgenie-package/Makefile
@@ -17,10 +17,12 @@ img.publish:
 	@$(OK) Image publish skipped for $(IMAGE)
 
 img.build:
-	@$(INFO) docker build $(IMAGE)
+	@$(INFO) docker build $(IMAGE):$(VERSION)
 	@cp Dockerfile $(IMAGE_TEMP_DIR) || $(FAIL)
 	@cp -R ../../../package $(IMAGE_TEMP_DIR) || $(FAIL)
 	@cd $(IMAGE_TEMP_DIR) && find package -type f -name '*.yaml' -exec cat {} >> 'package.yaml' \; -exec printf '\n---\n' \; || $(FAIL)
-	@docker build -t $(IMAGE) $(IMAGE_TEMP_DIR) || $(FAIL)
+	@docker buildx build --load \
+		--platform $(IMAGE_PLATFORMS) \
+		-t $(IMAGE) $(IMAGE_TEMP_DIR) || $(FAIL)
 	@docker tag $(IMAGE) "$(IMAGE):$(VERSION)" || $(FAIL)
-	@$(OK) docker build $(IMAGE)
+	@$(OK) Finished the docker build

--- a/cluster/images/provider-opsgenie/Makefile
+++ b/cluster/images/provider-opsgenie/Makefile
@@ -12,9 +12,9 @@ include ../../../build/makelib/imagelight.mk
 # Targets
 
 img.build:
-	@$(INFO) docker build $(IMAGE)
+	@$(INFO) docker build $(IMAGE):$(VERSION)
 	@$(MAKE) BUILD_ARGS="--load" img.build.shared
-	@$(OK) docker build $(IMAGE)
+	@$(OK) Finished the docker build
 
 img.publish:
 	@$(INFO) Skipping image publish for $(IMAGE)
@@ -33,8 +33,7 @@ img.build.shared:
 		--build-arg TERRAFORM_PROVIDER_DOWNLOAD_NAME=$(TERRAFORM_PROVIDER_DOWNLOAD_NAME) \
 		--build-arg TERRAFORM_PROVIDER_DOWNLOAD_URL_PREFIX=$(TERRAFORM_PROVIDER_DOWNLOAD_URL_PREFIX) \
 		--build-arg TERRAFORM_NATIVE_PROVIDER_BINARY=$(TERRAFORM_NATIVE_PROVIDER_BINARY) \
-		-t $(IMAGE) \
-		$(IMAGE_TEMP_DIR) || $(FAIL)
+		-t $(IMAGE)	$(IMAGE_TEMP_DIR) || $(FAIL)
 	@docker tag $(IMAGE) "$(IMAGE):$(VERSION)" || $(FAIL)
 
 img.promote:


### PR DESCRIPTION
### Description of your changes

Added a release pipeline.
When ever a tag is created eg. with the `make tag v0.1.0` command, the pipeline will run, the two container images will be created, taged and pushed to our Artifact Registry. The last job will create a Github release with a auto generated description.